### PR TITLE
pass skeletor API object to plugins and organize tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,15 +36,17 @@ const skeletor = () => {
 			options.logger = logger;
 		}
 
-		return taskRunner.runTask(taskConfig, options);
+		return taskRunner.runTask(taskConfig, options, api);
 	};
 
-	return {
+	const api = {
 		getConfig,
 		setConfig,
 		setLogger,
 		runTask
 	};
+
+	return api;
 };
 
 module.exports = skeletor;

--- a/lib/__mocks__/path.js
+++ b/lib/__mocks__/path.js
@@ -2,9 +2,7 @@
 
 const path = jest.genMockFromModule('path');
 
-const resolve = (...args) => {
-	return args[args.length - 1];
-};
+const resolve = (...args) => args[args.length - 1];
 
 path.resolve = resolve;
 

--- a/lib/taskRunner.js
+++ b/lib/taskRunner.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const runTask = (taskConfig, options) => {
+const runTask = (taskConfig, options, api) => {
 	const {logger} = options;
 
 	logger.info(`Running "${taskConfig.name}" task`);
@@ -15,8 +15,8 @@ const runTask = (taskConfig, options) => {
 		return Promise.resolve(resultObj);
 	}
 	const result = taskConfig.subTasks ?
-		runSubTasks(taskConfig.subTasks, options) :
-		runPlugins(taskConfig.plugins, options);
+		runSubTasks(taskConfig.subTasks, options, api) :
+		runPlugins(taskConfig.plugins, options, api);
 
 	return result.then(statusObj => {
 		logger.info(`Task "${taskConfig.name}" is complete`);
@@ -24,11 +24,11 @@ const runTask = (taskConfig, options) => {
 	});
 };
 
-const runSubTasks = (subTasks, options) => {
+const runSubTasks = (subTasks, options, api) => {
 	const filteredSubTasks = filterSubTasks(subTasks, options.subTasksToInclude);
 
 	return Promise.all(
-			filteredSubTasks.map(subTask => runTask(subTask, options))
+			filteredSubTasks.map(subTask => runTask(subTask, options, api))
 		)
 		.then(statuses => ({subTasks: statuses}));
 };
@@ -38,22 +38,22 @@ const filterSubTasks = (subTasks, subTasksToInclude = []) =>
 		subTasks.filter(subTask => subTasksToInclude.includes(subTask.name)) :
 		subTasks;
 
-const runPlugins = (plugins, options) =>
-	Promise.all(plugins.map(pluginConfig => runPlugin(pluginConfig, options)))
+const runPlugins = (plugins, options, api) =>
+	Promise.all(plugins.map(pluginConfig => runPlugin(pluginConfig, options, api)))
 		.then(statuses => (
 			{
 				plugins: statuses
 			}
 	));
 
-const runPlugin = (pluginConfig, options) => {
+const runPlugin = (pluginConfig, options, api) => {
 	options.logger.info(`Running "${pluginConfig.name}" plugin`);
 
 	const pluginFilepath = path.resolve(process.cwd(), 'node_modules', pluginConfig.name);
 
 	const plugin = require(pluginFilepath);
-	
-	return plugin().run(pluginConfig.config, options)
+
+	return plugin().run(pluginConfig.config, options, api)
 		.then(() => ({
 			pluginName: pluginConfig.name,
 			status: 'complete'

--- a/tests/getConfig.test.js
+++ b/tests/getConfig.test.js
@@ -1,0 +1,13 @@
+const skeletor = require('../index');
+
+test('getConfig() returns null if no config has been set', () => {
+	const skel = skeletor();
+	expect(skel.getConfig()).toEqual(null);
+});
+
+test('getConfig() returns previously set config', () => {
+	const skel = skeletor();
+	const config = {tasks: [{name: 'task1'}]};
+	skel.setConfig(config);
+	expect(skel.getConfig()).toEqual(config);
+});


### PR DESCRIPTION
Skeletor core now passes an API object to a plugin's run()  method as a third parameter. This is primarily to accommodate plugins like watch that need access to skeletor's runTask() method

I also organized the tests into suites. 