### PR TITLE
added task config option to control NODE_ENV variable

### DIFF
--- a/lib/taskRunner.js
+++ b/lib/taskRunner.js
@@ -14,6 +14,8 @@ function runTask(taskConfig, options, api) {
 		return Promise.resolve(taskResult);
 	}
 
+	setEnvironment(taskConfig);
+
 	let runPromise;
 
 	if(taskConfig.subTasks) {
@@ -28,6 +30,12 @@ function runTask(taskConfig, options, api) {
 		logTaskResult(taskResult, logger);
 		return taskResult;
 	});
+}
+
+function setEnvironment(taskConfig) {
+	if(taskConfig.environment) {
+		process.env.NODE_ENV = taskConfig.environment;
+	}
 }
 
 function buildTaskResult(taskName, results, resultsType) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/core",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "The core engine for the Skeletor family of build tools",
   "main": "index.js",
   "scripts": {

--- a/tests/runTask.test.js
+++ b/tests/runTask.test.js
@@ -126,11 +126,35 @@ test('runTask() runs plugin', () => {
 			info: jest.fn()
 		}
 	};
-
+	
 	expect.assertions(2);
 	return skel.runTask('task1', pluginOptions)
 		.then(response => {
 			expect(runSpy.mock.calls.length).toEqual(1);
 			expect(runSpy.mock.calls[0]).toEqual([skeletorPluginConfig.config, pluginOptions, skel]);		
 		});
+});
+
+describe('runTask() sets the node environment variable', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+
+	afterEach(() => {
+		process.env.NODE_ENV = originalNodeEnv;
+	});
+
+	test('when the task config specifies production', () => {
+		const environment = 'production';
+
+		const prodConfig = {...validConfigWithPlugin};
+		prodConfig.tasks[0].environment = environment;
+
+		const skel = skeletor();
+		skel.setConfig(validConfigWithPlugin);
+		
+		expect.assertions(1);
+		return skel.runTask('task1')
+			.then(() => {
+				expect(process.env.NODE_ENV).toEqual(environment);
+			});
+	})
 });


### PR DESCRIPTION
Some tasks may need the NODE_ENV variable set to "production" in order for various plugins to produce production-ready output. Task configs can now have an optional `environment` property that the task runner will use to set NODE_ENV variable when that task is run:

`{
    name: 'export',
    environment: 'production'
}`

Interested to know what you guys think about this idea and/or the naming convention I used for the property.